### PR TITLE
liblognorm/Makefile replace PKG_SHA256SUM with PKG_HASH

### DIFF
--- a/packages/liblognorm/Makefile
+++ b/packages/liblognorm/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://www.liblognorm.com/files/download/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SHA256SUM:=730175b6e4e8818c31a60f614f8ba38aae4f8edbeb50d0e34236749e5d20b3a3
+PKG_HASH:=730175b6e4e8818c31a60f614f8ba38aae4f8edbeb50d0e34236749e5d20b3a3
 
 PKG_MAINTAINER:=Nicolas Pace <nico@libre.ws>
 PKG_LICENSE:=LGPL-2.1+


### PR DESCRIPTION
Compiling I got this error:
```
SHELL= flock /home/ilario/projects/gsoc2019/openwrt/tmp/.liblognorm-2.0.4.tar.gz.flock -c '  	/home/ilario/projects/gsoc2019/openwrt/scripts/download.pl "/home/ilario/projects/gsoc2019/openwrt/dl" "liblognorm-2.0.4.tar.gz" "x" "" "http://www.liblognorm.com/files/download/"    '
Cannot find appropriate hash command, ensure the provided hash is either a MD5 or SHA256 checksum.
```

so I replaced PKG_SHA256SUM with PKG_HASH which seems to be more commonly employed and now it works.